### PR TITLE
fix: one-off medication status shows "Taken" before confirmation

### DIFF
--- a/lib/src/features/medications/ui/daily_medication_list.dart
+++ b/lib/src/features/medications/ui/daily_medication_list.dart
@@ -55,12 +55,22 @@ class DailyMedicationList extends ConsumerWidget {
       itemCount: meds.length,
       itemBuilder: (context, index) {
         final med = meds[index];
+        final selectedDate = ref.watch(selectedDateProvider);
+        final isTaken = _isTaken(med, selectedDate);
         String subtitleText = med.type.name;
         if (med.type == MedicationType.oneOff) {
-          final timeString = DateFormat.Hm().format(med.startDate);
-          subtitleText = 'Taken at $timeString';
+          if (isTaken) {
+            final takenLog = med.takenLogs.firstWhere(
+              (log) =>
+                  log.year == selectedDate.year &&
+                  log.month == selectedDate.month &&
+                  log.day == selectedDate.day,
+            );
+            subtitleText = 'Taken at ${DateFormat.Hm().format(takenLog)}';
+          } else {
+            subtitleText = 'One-off';
+          }
         }
-        final isTaken = _isTaken(med, ref.watch(selectedDateProvider));
 
         return Card(
           margin: const EdgeInsets.only(bottom: 8),


### PR DESCRIPTION
Fixes #7

One-off medications were always displaying "Taken at [creation time]" regardless of whether the user had confirmed taking it.

The fix moves the `isTaken` computation before the subtitle logic, so one-off medications show "One-off" until confirmed, then "Taken at [HH:mm]" using the actual taken log timestamp.

Generated with [Claude Code](https://claude.ai/code)