### PR TITLE
fix: remove 3-item cap in History calendar view

### DIFF
--- a/lib/src/features/history/ui/history_page.dart
+++ b/lib/src/features/history/ui/history_page.dart
@@ -67,7 +67,7 @@ class _HistoryPageState extends ConsumerState<HistoryPage> {
                 return ListView.builder(
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(), // Don't scroll inside the cell
-                  itemCount: dayEvents.length > 3 ? 3 : dayEvents.length, // Max 3 items per cell
+                  itemCount: dayEvents.length,
                   itemBuilder: (context, index) {
                     final event = dayEvents[index] as HistoryEvent;
                     return _buildEventBar(event);


### PR DESCRIPTION
Remove the hard cap of 3 items per day in the History calendar view, so all events on high-activity days are displayed.

Closes #4

Generated with [Claude Code](https://claude.ai/code)