### PR TITLE
fix: History tab - show note for Other symptoms with sentence-case labels

### DIFF
--- a/lib/src/features/history/logic/history_provider.dart
+++ b/lib/src/features/history/logic/history_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/models/medication.dart';
+import '../../../core/models/symptom.dart';
 import '../../family/logic/family_provider.dart';
 import '../../medications/logic/medication_provider.dart';
 import '../../symptoms/logic/symptom_provider.dart';
@@ -33,7 +34,9 @@ final historyEventsProvider = Provider<Map<DateTime, List<HistoryEvent>>>((ref) 
   for (final s in symptoms) {
     addEvent(s.timestamp, HistoryEvent(
       id: s.id,
-      title: s.type.name.toUpperCase(),
+      title: s.type == SymptomType.other && s.note != null && s.note!.isNotEmpty
+          ? s.note!
+          : s.type.name[0].toUpperCase() + s.type.name.substring(1),
       date: s.timestamp,
       color: getFamilyColor(s.familyMemberId),
       type: EventType.symptom,

--- a/test/features/history/logic/history_provider_test.dart
+++ b/test/features/history/logic/history_provider_test.dart
@@ -68,7 +68,7 @@ void main() {
         container.dispose();
       });
 
-      test('title is type name uppercased', () {
+      test('title is type name in sentence case', () {
         final symptoms = [
           Symptom(
             id: 's1',
@@ -82,7 +82,44 @@ void main() {
         final events = container.read(historyEventsProvider);
         final event = events[normalize(DateTime(2025, 6, 15))]!.first;
 
-        expect(event.title, 'FEVER');
+        expect(event.title, 'Fever');
+        container.dispose();
+      });
+
+      test('other symptom with note uses note as title', () {
+        final symptoms = [
+          Symptom(
+            id: 's1',
+            familyMemberId: 'fm-1',
+            timestamp: DateTime(2025, 6, 15),
+            type: SymptomType.other,
+            note: 'Stomach ache',
+          ),
+        ];
+
+        final container = makeContainer(symptoms: symptoms);
+        final events = container.read(historyEventsProvider);
+        final event = events[normalize(DateTime(2025, 6, 15))]!.first;
+
+        expect(event.title, 'Stomach ache');
+        container.dispose();
+      });
+
+      test('other symptom without note falls back to sentence-case type name', () {
+        final symptoms = [
+          Symptom(
+            id: 's1',
+            familyMemberId: 'fm-1',
+            timestamp: DateTime(2025, 6, 15),
+            type: SymptomType.other,
+          ),
+        ];
+
+        final container = makeContainer(symptoms: symptoms);
+        final events = container.read(historyEventsProvider);
+        final event = events[normalize(DateTime(2025, 6, 15))]!.first;
+
+        expect(event.title, 'Other');
         container.dispose();
       });
 


### PR DESCRIPTION
Fixes #21

- Display the user's custom note as the title when symptom type is "Other"
- Fall back to sentence-case type name (e.g. "Other", "Fever") when no note is present
- All symptom labels now use sentence-case instead of all-caps

Generated with [Claude Code](https://claude.ai/code)