### PR TITLE
fix: UI fixes - button clipping and today date highlight

### DIFF
--- a/lib/src/features/medications/ui/add_medication_sheet.dart
+++ b/lib/src/features/medications/ui/add_medication_sheet.dart
@@ -90,9 +90,11 @@ class _AddMedicationSheetState extends ConsumerState<AddMedicationSheet> {
     }
 
     return Padding(
-      // This padding makes the sheet avoid the keyboard when it opens
+      // This padding makes the sheet avoid the keyboard when it opens,
+      // and also accounts for the system navigation bar (Back/Home/Recents).
       padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).viewInsets.bottom,
+        bottom: MediaQuery.of(context).viewInsets.bottom +
+            MediaQuery.of(context).padding.bottom,
         left: 16,
         right: 16,
         top: 16,

--- a/lib/src/features/medications/ui/date_strip.dart
+++ b/lib/src/features/medications/ui/date_strip.dart
@@ -36,6 +36,7 @@ class DateStrip extends ConsumerWidget {
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: weekDates.map((date) {
                 final isSelected = _isSameDay(date, selectedDate);
+                final isToday = _isSameDay(date, DateTime.now());
                 return GestureDetector(
                   onTap: () {
                     ref.read(selectedDateProvider.notifier).state = date;
@@ -45,6 +46,7 @@ class DateStrip extends ConsumerWidget {
                   child: _DateCard(
                     date: date,
                     isSelected: isSelected,
+                    isToday: isToday,
                   ),
                 );
               }).toList(),
@@ -66,27 +68,38 @@ class DateStrip extends ConsumerWidget {
 class _DateCard extends StatelessWidget {
   final DateTime date;
   final bool isSelected;
+  final bool isToday;
 
-  const _DateCard({required this.date, required this.isSelected});
+  const _DateCard({required this.date, required this.isSelected, required this.isToday});
 
   @override
   Widget build(BuildContext context) {
+    final primaryColor = Theme.of(context).primaryColor;
     return Container(
       width: 50,
       height: 60,
       decoration: BoxDecoration(
-        color: isSelected ? Theme.of(context).primaryColor : Colors.transparent,
+        color: isSelected ? primaryColor : Colors.transparent,
         borderRadius: BorderRadius.circular(12),
-        border: isSelected ? null : Border.all(color: Colors.grey.shade300),
+        border: isSelected
+            ? null
+            : isToday
+                ? Border.all(color: primaryColor, width: 2)
+                : Border.all(color: Colors.grey.shade300),
       ),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Text(
-            DateFormat('E').format(date),
+            isToday ? 'Today' : DateFormat('E').format(date),
             style: TextStyle(
               fontSize: 10,
-              color: isSelected ? Colors.white : Colors.grey,
+              fontWeight: isToday ? FontWeight.bold : FontWeight.normal,
+              color: isSelected
+                  ? Colors.white
+                  : isToday
+                      ? primaryColor
+                      : Colors.grey,
             ),
           ),
           const SizedBox(height: 4),
@@ -95,7 +108,11 @@ class _DateCard extends StatelessWidget {
             style: TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.bold,
-              color: isSelected ? Colors.white : Colors.black,
+              color: isSelected
+                  ? Colors.white
+                  : isToday
+                      ? primaryColor
+                      : Colors.black,
             ),
           ),
         ],

--- a/lib/src/features/symptoms/ui/add_symptom_sheet.dart
+++ b/lib/src/features/symptoms/ui/add_symptom_sheet.dart
@@ -57,8 +57,11 @@ class _AddSymptomSheetState extends ConsumerState<AddSymptomSheet> {
     final familyMembers = ref.watch(familyProvider);
 
     return Padding(
+      // This padding makes the sheet avoid the keyboard when it opens,
+      // and also accounts for the system navigation bar (Back/Home/Recents).
       padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).viewInsets.bottom,
+        bottom: MediaQuery.of(context).viewInsets.bottom +
+            MediaQuery.of(context).padding.bottom,
         left: 16,
         right: 16,
         top: 16,


### PR DESCRIPTION
Fixes #19

## Changes

- Add `MediaQuery.padding.bottom` to Add Medication and Add Symptom bottom sheets so Save buttons are not obscured by Android system navigation bar
- Highlight today's date in the date strip with a primary-color border, "Today" label, and primary-color text

Generated with [Claude Code](https://claude.ai/code)