### PR TITLE
feat: auto-check one-offs and smart deletion for temp/permanent meds

### DIFF
--- a/lib/src/features/medications/logic/medication_provider.dart
+++ b/lib/src/features/medications/logic/medication_provider.dart
@@ -51,6 +51,10 @@ class MedicationNotifier extends StateNotifier<List<Medication>> {
     int? durationInDays,
   }) async {
     final id = const Uuid().v4();
+    // Auto-check one-off medications immediately on creation
+    final takenLogs = type == MedicationType.oneOff
+        ? [DateTime(startDate.year, startDate.month, startDate.day)]
+        : <DateTime>[];
     final newMed = Medication(
       id: id,
       name: name,
@@ -58,6 +62,7 @@ class MedicationNotifier extends StateNotifier<List<Medication>> {
       type: type,
       startDate: startDate,
       durationInDays: durationInDays,
+      takenLogs: takenLogs,
     );
     await _col.doc(id).set(newMed.toMap());
   }
@@ -82,7 +87,43 @@ class MedicationNotifier extends StateNotifier<List<Medication>> {
   }
 
   Future<void> deleteMedication(String id) async {
-    await _col.doc(id).delete();
+    final med = state.firstWhere((m) => m.id == id);
+
+    // One-off medications are always fully deleted
+    if (med.type == MedicationType.oneOff) {
+      await _col.doc(id).delete();
+      return;
+    }
+
+    // For temporary/permanent: preserve past history, delete only future
+    final today = DateTime.now();
+    final normalizedToday = DateTime(today.year, today.month, today.day);
+    final normalizedStart = DateTime(
+      med.startDate.year,
+      med.startDate.month,
+      med.startDate.day,
+    );
+
+    // No past days to preserve — fully delete
+    if (!normalizedStart.isBefore(normalizedToday)) {
+      await _col.doc(id).delete();
+      return;
+    }
+
+    // Keep only taken logs from before today
+    final pastLogs = med.takenLogs.where((log) {
+      final normalizedLog = DateTime(log.year, log.month, log.day);
+      return normalizedLog.isBefore(normalizedToday);
+    }).toList();
+
+    // Truncate the medication to cover only past days (startDate to yesterday)
+    final daysToPreserve = normalizedToday.difference(normalizedStart).inDays;
+    final preserved = med.copyWith(
+      type: MedicationType.temporary,
+      durationInDays: daysToPreserve,
+      takenLogs: pastLogs,
+    );
+    await _col.doc(id).set(preserved.toMap());
   }
 
   Future<void> toggleTaken(String id, DateTime date) async {

--- a/lib/src/features/medications/logic/medication_provider.dart
+++ b/lib/src/features/medications/logic/medication_provider.dart
@@ -110,14 +110,22 @@ class MedicationNotifier extends StateNotifier<List<Medication>> {
       return;
     }
 
-    // Keep only taken logs from before today
+    // Keep only taken logs from before today. Any log for today is intentionally
+    // excluded because the preserved document ends yesterday (the deletion point),
+    // so including a today-log would reference a day outside the medication's new range.
     final pastLogs = med.takenLogs.where((log) {
       final normalizedLog = DateTime(log.year, log.month, log.day);
       return normalizedLog.isBefore(normalizedToday);
     }).toList();
 
-    // Truncate the medication to cover only past days (startDate to yesterday)
-    final daysToPreserve = normalizedToday.difference(normalizedStart).inDays;
+    // Truncate the medication to cover only past days (startDate to yesterday).
+    // For temporary medications cap to the original duration so we never extend
+    // a medication that had already ended before the deletion date.
+    final diff = normalizedToday.difference(normalizedStart).inDays;
+    final daysToPreserve =
+        (med.type == MedicationType.temporary && med.durationInDays != null)
+            ? (diff < med.durationInDays! ? diff : med.durationInDays!)
+            : diff;
     final preserved = med.copyWith(
       type: MedicationType.temporary,
       durationInDays: daysToPreserve,

--- a/test/features/medications/logic/medication_provider_test.dart
+++ b/test/features/medications/logic/medication_provider_test.dart
@@ -38,6 +38,51 @@ void main() {
         expect(notifier.state.first.type, MedicationType.oneOff);
       });
 
+      test('auto-checks a oneOff medication on creation', () async {
+        final notifier = createNotifier();
+        final startDate = DateTime(2025, 6, 15);
+        await notifier.addMedication(
+          name: 'Ibuprofen',
+          familyMemberId: 'fm-1',
+          type: MedicationType.oneOff,
+          startDate: startDate,
+        );
+        await Future.delayed(Duration.zero);
+
+        expect(notifier.state.first.takenLogs.length, 1);
+        final log = notifier.state.first.takenLogs.first;
+        expect(log.year, startDate.year);
+        expect(log.month, startDate.month);
+        expect(log.day, startDate.day);
+      });
+
+      test('does not auto-check a temporary medication', () async {
+        final notifier = createNotifier();
+        await notifier.addMedication(
+          name: 'Amoxicillin',
+          familyMemberId: 'fm-1',
+          type: MedicationType.temporary,
+          startDate: DateTime(2025, 6, 15),
+          durationInDays: 7,
+        );
+        await Future.delayed(Duration.zero);
+
+        expect(notifier.state.first.takenLogs, isEmpty);
+      });
+
+      test('does not auto-check a permanent medication', () async {
+        final notifier = createNotifier();
+        await notifier.addMedication(
+          name: 'Vitamin D',
+          familyMemberId: 'fm-1',
+          type: MedicationType.permanent,
+          startDate: DateTime(2025, 1, 1),
+        );
+        await Future.delayed(Duration.zero);
+
+        expect(notifier.state.first.takenLogs, isEmpty);
+      });
+
       test('adds a temporary medication with duration', () async {
         final notifier = createNotifier();
         await notifier.addMedication(
@@ -123,13 +168,92 @@ void main() {
     });
 
     group('deleteMedication', () {
-      test('removes from Firestore', () async {
+      test('fully deletes a oneOff medication', () async {
         final notifier = createNotifier();
         await notifier.addMedication(
           name: 'To Delete',
           familyMemberId: 'fm-1',
           type: MedicationType.oneOff,
           startDate: DateTime(2025, 6, 15),
+        );
+        await Future.delayed(Duration.zero);
+        final id = notifier.state.first.id;
+
+        await notifier.deleteMedication(id);
+
+        final snap = await medsCol().get();
+        expect(snap.docs, isEmpty);
+      });
+
+      test('preserves past history when deleting a permanent medication', () async {
+        final notifier = createNotifier();
+        final startDate = DateTime(2025, 1, 1);
+        await notifier.addMedication(
+          name: 'Vitamin D',
+          familyMemberId: 'fm-1',
+          type: MedicationType.permanent,
+          startDate: startDate,
+        );
+        await Future.delayed(Duration.zero);
+        final id = notifier.state.first.id;
+
+        await notifier.deleteMedication(id);
+        await Future.delayed(Duration.zero);
+
+        // Document must still exist (past history preserved)
+        final snap = await medsCol().get();
+        expect(snap.docs.length, 1);
+
+        // Must be converted to temporary type
+        final data = snap.docs.first.data() as Map<String, dynamic>;
+        expect(data['type'], MedicationType.temporary.name);
+
+        // Duration covers startDate up to (but not including) today
+        final now = DateTime.now();
+        final normalizedToday = DateTime(now.year, now.month, now.day);
+        final normalizedStart = DateTime(startDate.year, startDate.month, startDate.day);
+        final expectedDays = normalizedToday.difference(normalizedStart).inDays;
+        expect(data['durationInDays'], expectedDays);
+      });
+
+      test('preserves past history when deleting a temporary medication that extends into the future', () async {
+        final notifier = createNotifier();
+        final startDate = DateTime(2025, 1, 1);
+        await notifier.addMedication(
+          name: 'Antibiotic',
+          familyMemberId: 'fm-1',
+          type: MedicationType.temporary,
+          startDate: startDate,
+          durationInDays: 3650, // extends well into the future
+        );
+        await Future.delayed(Duration.zero);
+        final id = notifier.state.first.id;
+
+        await notifier.deleteMedication(id);
+        await Future.delayed(Duration.zero);
+
+        // Document must still exist
+        final snap = await medsCol().get();
+        expect(snap.docs.length, 1);
+
+        // Duration must be truncated to past-only
+        final data = snap.docs.first.data() as Map<String, dynamic>;
+        expect(data['type'], MedicationType.temporary.name);
+        final now = DateTime.now();
+        final normalizedToday = DateTime(now.year, now.month, now.day);
+        final normalizedStart = DateTime(startDate.year, startDate.month, startDate.day);
+        final expectedDays = normalizedToday.difference(normalizedStart).inDays;
+        expect(data['durationInDays'], expectedDays);
+      });
+
+      test('fully deletes a permanent medication that starts today or in the future', () async {
+        final notifier = createNotifier();
+        final today = DateTime.now();
+        await notifier.addMedication(
+          name: 'Vitamin D',
+          familyMemberId: 'fm-1',
+          type: MedicationType.permanent,
+          startDate: today,
         );
         await Future.delayed(Duration.zero);
         final id = notifier.state.first.id;
@@ -154,8 +278,9 @@ void main() {
         await notifier.addMedication(
           name: 'Toggle Med',
           familyMemberId: 'fm-1',
-          type: MedicationType.oneOff,
+          type: MedicationType.temporary,
           startDate: today,
+          durationInDays: 7,
         );
         await Future.delayed(Duration.zero);
         final id = notifier.state.first.id;
@@ -171,8 +296,9 @@ void main() {
         await notifier.addMedication(
           name: 'Toggle Med',
           familyMemberId: 'fm-1',
-          type: MedicationType.oneOff,
+          type: MedicationType.temporary,
           startDate: today,
+          durationInDays: 7,
         );
         await Future.delayed(Duration.zero);
         final id = notifier.state.first.id;
@@ -191,8 +317,9 @@ void main() {
         await notifier.addMedication(
           name: 'Toggle Med',
           familyMemberId: 'fm-1',
-          type: MedicationType.oneOff,
+          type: MedicationType.temporary,
           startDate: today,
+          durationInDays: 7,
         );
         await Future.delayed(Duration.zero);
         final id = notifier.state.first.id;

--- a/test/features/medications/logic/medication_provider_test.dart
+++ b/test/features/medications/logic/medication_provider_test.dart
@@ -246,6 +246,34 @@ void main() {
         expect(data['durationInDays'], expectedDays);
       });
 
+      test('does not extend an already-ended temporary medication on deletion', () async {
+        final notifier = createNotifier();
+        // Medication ran Jan 1–3 (3 days), deleted well after it ended
+        final startDate = DateTime(2025, 1, 1);
+        const originalDuration = 3;
+        await notifier.addMedication(
+          name: 'Short Course',
+          familyMemberId: 'fm-1',
+          type: MedicationType.temporary,
+          startDate: startDate,
+          durationInDays: originalDuration,
+        );
+        await Future.delayed(Duration.zero);
+        final id = notifier.state.first.id;
+
+        await notifier.deleteMedication(id);
+        await Future.delayed(Duration.zero);
+
+        // Document must still exist
+        final snap = await medsCol().get();
+        expect(snap.docs.length, 1);
+
+        // Duration must NOT exceed the original duration
+        final data = snap.docs.first.data() as Map<String, dynamic>;
+        expect(data['type'], MedicationType.temporary.name);
+        expect(data['durationInDays'], originalDuration);
+      });
+
       test('fully deletes a permanent medication that starts today or in the future', () async {
         final notifier = createNotifier();
         final today = DateTime.now();


### PR DESCRIPTION
Fixes #20

## Changes

- **Auto-Check One-offs**: one-off medications are immediately marked as taken on creation (takenLogs initialized with normalized startDate).
- **Smart Deletion**: deleting a temporary or permanent medication that has already started now preserves past history as a truncated temporary medication instead of deleting the document outright. Future instances are removed; past logs are kept for medical record accuracy.
- Updated and expanded unit tests to cover both new behaviors.

Generated with [Claude Code](https://claude.ai/code)