### PR TITLE
feat: Enhance timestamp management for medications and symptoms

### DIFF
--- a/lib/src/features/medications/logic/medication_provider.dart
+++ b/lib/src/features/medications/logic/medication_provider.dart
@@ -107,6 +107,12 @@ class MedicationNotifier extends StateNotifier<List<Medication>> {
   }
 
   Future<void> setTakenTime(String id, DateTime date, DateTime newTakenAt) async {
+    assert(
+      newTakenAt.year == date.year &&
+          newTakenAt.month == date.month &&
+          newTakenAt.day == date.day,
+      'newTakenAt must be on the same calendar day as date',
+    );
     final med = state.firstWhere((med) => med.id == id);
 
     final existingLogIndex = med.takenLogs.indexWhere((log) =>

--- a/lib/src/features/medications/logic/medication_provider.dart
+++ b/lib/src/features/medications/logic/medication_provider.dart
@@ -85,7 +85,7 @@ class MedicationNotifier extends StateNotifier<List<Medication>> {
     await _col.doc(id).delete();
   }
 
-  Future<void> toggleTaken(String id, DateTime date) async {
+  Future<void> toggleTaken(String id, DateTime date, {DateTime? takenAt}) async {
     final med = state.firstWhere((med) => med.id == id);
     final targetDay = DateTime(date.year, date.month, date.day);
 
@@ -99,8 +99,25 @@ class MedicationNotifier extends StateNotifier<List<Medication>> {
     if (existingLogIndex >= 0) {
       newLogs.removeAt(existingLogIndex);
     } else {
-      newLogs.add(DateTime.now());
+      newLogs.add(takenAt ?? DateTime.now());
     }
+
+    final updatedMed = med.copyWith(takenLogs: newLogs);
+    await _col.doc(id).set(updatedMed.toMap());
+  }
+
+  Future<void> setTakenTime(String id, DateTime date, DateTime newTakenAt) async {
+    final med = state.firstWhere((med) => med.id == id);
+
+    final existingLogIndex = med.takenLogs.indexWhere((log) =>
+        log.year == date.year &&
+        log.month == date.month &&
+        log.day == date.day);
+
+    if (existingLogIndex < 0) return;
+
+    List<DateTime> newLogs = [...med.takenLogs];
+    newLogs[existingLogIndex] = newTakenAt;
 
     final updatedMed = med.copyWith(takenLogs: newLogs);
     await _col.doc(id).set(updatedMed.toMap());

--- a/lib/src/features/medications/ui/daily_medication_list.dart
+++ b/lib/src/features/medications/ui/daily_medication_list.dart
@@ -41,6 +41,122 @@ bool _isTaken(Medication med, DateTime date) {
   );
 }
 
+/// Dialog shown when marking a medication as taken, allowing the user to set
+/// an exact time with a "Now" shortcut and a manual time picker.
+class _TakenTimeDialog extends StatefulWidget {
+  final DateTime date;
+  final TimeOfDay? initialTime;
+
+  const _TakenTimeDialog({required this.date, this.initialTime});
+
+  @override
+  State<_TakenTimeDialog> createState() => _TakenTimeDialogState();
+}
+
+class _TakenTimeDialogState extends State<_TakenTimeDialog> {
+  late TimeOfDay _time;
+
+  @override
+  void initState() {
+    super.initState();
+    _time = widget.initialTime ?? TimeOfDay.now();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('When was it taken?'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Text(
+                _time.format(context),
+                style: const TextStyle(fontSize: 28, fontWeight: FontWeight.bold),
+              ),
+              const Spacer(),
+              OutlinedButton(
+                onPressed: () => setState(() => _time = TimeOfDay.now()),
+                child: const Text('Now'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          TextButton.icon(
+            icon: const Icon(Icons.access_time),
+            label: const Text('Pick a different time'),
+            onPressed: () async {
+              final picked = await showTimePicker(
+                context: context,
+                initialTime: _time,
+              );
+              if (picked != null) setState(() => _time = picked);
+            },
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () {
+            final result = DateTime(
+              widget.date.year,
+              widget.date.month,
+              widget.date.day,
+              _time.hour,
+              _time.minute,
+            );
+            Navigator.pop(context, result);
+          },
+          child: const Text('Confirm'),
+        ),
+      ],
+    );
+  }
+}
+
+Future<void> _showToggleTakenDialog(
+  BuildContext context,
+  WidgetRef ref,
+  Medication med,
+  DateTime selectedDate,
+) async {
+  final takenAt = await showDialog<DateTime>(
+    context: context,
+    builder: (ctx) => _TakenTimeDialog(date: selectedDate),
+  );
+  if (takenAt != null && context.mounted) {
+    ref
+        .read(medicationProvider.notifier)
+        .toggleTaken(med.id, selectedDate, takenAt: takenAt);
+  }
+}
+
+Future<void> _showEditTakenTimeDialog(
+  BuildContext context,
+  WidgetRef ref,
+  Medication med,
+  DateTime selectedDate,
+  DateTime currentTakenAt,
+) async {
+  final newTakenAt = await showDialog<DateTime>(
+    context: context,
+    builder: (ctx) => _TakenTimeDialog(
+      date: selectedDate,
+      initialTime: TimeOfDay.fromDateTime(currentTakenAt),
+    ),
+  );
+  if (newTakenAt != null && context.mounted) {
+    ref
+        .read(medicationProvider.notifier)
+        .setTakenTime(med.id, selectedDate, newTakenAt);
+  }
+}
+
 class DailyMedicationList extends ConsumerWidget {
   const DailyMedicationList({super.key});
 
@@ -60,18 +176,28 @@ class DailyMedicationList extends ConsumerWidget {
         final med = meds[index];
         final selectedDate = ref.watch(selectedDateProvider);
         final isTaken = _isTaken(med, selectedDate);
-        String subtitleText = med.type.name;
-        if (med.type == MedicationType.oneOff) {
-          if (isTaken) {
-            final takenLog = med.takenLogs.firstWhere(
-              (log) =>
-                  log.year == selectedDate.year &&
-                  log.month == selectedDate.month &&
-                  log.day == selectedDate.day,
-            );
-            subtitleText = 'Taken at ${DateFormat.Hm().format(takenLog)}';
-          } else {
-            subtitleText = 'One-off';
+
+        DateTime? takenLog;
+        if (isTaken) {
+          takenLog = med.takenLogs.firstWhere(
+            (log) =>
+                log.year == selectedDate.year &&
+                log.month == selectedDate.month &&
+                log.day == selectedDate.day,
+          );
+        }
+
+        String subtitleText;
+        if (isTaken && takenLog != null) {
+          subtitleText = 'Taken at ${DateFormat.Hm().format(takenLog)}';
+        } else {
+          switch (med.type) {
+            case MedicationType.oneOff:
+              subtitleText = 'One-off';
+            case MedicationType.temporary:
+              subtitleText = 'Temporary';
+            case MedicationType.permanent:
+              subtitleText = 'Permanent';
           }
         }
 
@@ -87,9 +213,13 @@ class DailyMedicationList extends ConsumerWidget {
             leading: Checkbox(
               value: isTaken,
               onChanged: (val) {
-                ref
-                    .read(medicationProvider.notifier)
-                    .toggleTaken(med.id, ref.watch(selectedDateProvider));
+                if (val == true) {
+                  _showToggleTakenDialog(context, ref, med, selectedDate);
+                } else {
+                  ref
+                      .read(medicationProvider.notifier)
+                      .toggleTaken(med.id, selectedDate);
+                }
               },
             ),
             title: Text(
@@ -116,11 +246,29 @@ class DailyMedicationList extends ConsumerWidget {
                     ),
                   ],
                 ),
-                Text(subtitleText),
+                if (isTaken && takenLog != null)
+                  GestureDetector(
+                    onTap: () => _showEditTakenTimeDialog(
+                      context, ref, med, selectedDate, takenLog!,
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          subtitleText,
+                          style: const TextStyle(color: Colors.green),
+                        ),
+                        const SizedBox(width: 4),
+                        const Icon(Icons.edit, size: 12, color: Colors.green),
+                      ],
+                    ),
+                  )
+                else
+                  Text(subtitleText),
               ],
             ),
             trailing: Row(
-              mainAxisSize: MainAxisSize.min, // <-- CRITICAL
+              mainAxisSize: MainAxisSize.min,
               children: [
                 IconButton(
                   icon: const Icon(Icons.edit, color: Colors.grey),

--- a/lib/src/features/medications/ui/daily_medication_list.dart
+++ b/lib/src/features/medications/ui/daily_medication_list.dart
@@ -34,12 +34,6 @@ void _confirmDelete(BuildContext context, WidgetRef ref, Medication med) {
   );
 }
 
-bool _isTaken(Medication med, DateTime date) {
-  return med.takenLogs.any(
-    (log) =>
-        log.year == date.year && log.month == date.month && log.day == date.day,
-  );
-}
 
 /// Dialog shown when marking a medication as taken, allowing the user to set
 /// an exact time with a "Now" shortcut and a manual time picker.
@@ -164,6 +158,7 @@ class DailyMedicationList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final meds = ref.watch(dailyMedicationsProvider);
     final familyMembers = ref.watch(familyProvider);
+    final selectedDate = ref.watch(selectedDateProvider);
 
     if (meds.isEmpty) {
       return const Center(child: Text('No medications for the selected date.'));
@@ -174,18 +169,13 @@ class DailyMedicationList extends ConsumerWidget {
       itemCount: meds.length,
       itemBuilder: (context, index) {
         final med = meds[index];
-        final selectedDate = ref.watch(selectedDateProvider);
-        final isTaken = _isTaken(med, selectedDate);
-
-        DateTime? takenLog;
-        if (isTaken) {
-          takenLog = med.takenLogs.firstWhere(
-            (log) =>
-                log.year == selectedDate.year &&
-                log.month == selectedDate.month &&
-                log.day == selectedDate.day,
-          );
-        }
+        final takenLog = med.takenLogs.where(
+          (log) =>
+              log.year == selectedDate.year &&
+              log.month == selectedDate.month &&
+              log.day == selectedDate.day,
+        ).firstOrNull;
+        final isTaken = takenLog != null;
 
         String subtitleText;
         if (isTaken && takenLog != null) {

--- a/lib/src/features/symptoms/ui/add_symptom_sheet.dart
+++ b/lib/src/features/symptoms/ui/add_symptom_sheet.dart
@@ -22,6 +22,7 @@ class _AddSymptomSheetState extends ConsumerState<AddSymptomSheet> {
   double _tempValue = 38.5;
   String _coughType = 'Dry';
   final TextEditingController _noteController = TextEditingController();
+  late TimeOfDay _selectedTime;
 
   @override
   void initState() {
@@ -32,6 +33,7 @@ class _AddSymptomSheetState extends ConsumerState<AddSymptomSheet> {
       _selectedMemberId = symptom.familyMemberId;
       _selectedType = symptom.type;
       _noteController.text = symptom.note ?? '';
+      _selectedTime = TimeOfDay.fromDateTime(symptom.timestamp);
 
       if (symptom.type == SymptomType.fever &&
           symptom.data.containsKey('temp')) {
@@ -41,6 +43,7 @@ class _AddSymptomSheetState extends ConsumerState<AddSymptomSheet> {
         _coughType = symptom.data['style'];
       }
     } else {
+      _selectedTime = TimeOfDay.now();
       WidgetsBinding.instance.addPostFrameCallback((_) {
         final familyMembers = ref.read(familyProvider);
         if (familyMembers.isNotEmpty && _selectedMemberId == null) {
@@ -144,6 +147,37 @@ class _AddSymptomSheetState extends ConsumerState<AddSymptomSheet> {
 
           const Divider(height: 30),
 
+          // TIME PICKER ROW
+          Row(
+            children: [
+              const Icon(Icons.access_time, size: 18, color: Colors.grey),
+              const SizedBox(width: 8),
+              Text(
+                _selectedTime.format(context),
+                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+              ),
+              const Spacer(),
+              OutlinedButton(
+                onPressed: () => setState(() => _selectedTime = TimeOfDay.now()),
+                child: const Text('Now'),
+              ),
+              const SizedBox(width: 8),
+              OutlinedButton.icon(
+                icon: const Icon(Icons.edit, size: 16),
+                label: const Text('Pick'),
+                onPressed: () async {
+                  final picked = await showTimePicker(
+                    context: context,
+                    initialTime: _selectedTime,
+                  );
+                  if (picked != null) setState(() => _selectedTime = picked);
+                },
+              ),
+            ],
+          ),
+
+          const Divider(height: 30),
+
           // DETAILS
           _buildDynamicDetails(),
 
@@ -203,13 +237,18 @@ class _AddSymptomSheetState extends ConsumerState<AddSymptomSheet> {
 
     // Edit mode
     if (widget.symptomToEdit != null) {
+      final st = widget.symptomToEdit!.timestamp;
+      final updatedTimestamp = DateTime(
+        st.year, st.month, st.day,
+        _selectedTime.hour, _selectedTime.minute,
+      );
       ref
           .read(symptomProvider.notifier)
           .editSymptom(
             id: widget.symptomToEdit!.id,
             familyMemberId: _selectedMemberId!,
             type: _selectedType,
-            timestamp: widget.symptomToEdit!.timestamp,
+            timestamp: updatedTimestamp,
             data: data,
             note: _noteController.text.isEmpty ? null : _noteController.text,
           );
@@ -217,13 +256,12 @@ class _AddSymptomSheetState extends ConsumerState<AddSymptomSheet> {
     // Add mode
     else {
       final selectedDate = ref.read(selectedDateProvider);
-      final now = DateTime.now();
       final timestamp = DateTime(
         selectedDate.year,
         selectedDate.month,
         selectedDate.day,
-        now.hour,
-        now.minute,
+        _selectedTime.hour,
+        _selectedTime.minute,
       );
       ref
           .read(symptomProvider.notifier)

--- a/test/features/medications/logic/medication_provider_test.dart
+++ b/test/features/medications/logic/medication_provider_test.dart
@@ -205,6 +205,76 @@ void main() {
         await Future.delayed(Duration.zero);
         expect(notifier.state.first.takenLogs.length, 0);
       });
+
+      test('stores the exact takenAt timestamp when provided', () async {
+        final notifier = createNotifier();
+        await notifier.addMedication(
+          name: 'Toggle Med',
+          familyMemberId: 'fm-1',
+          type: MedicationType.oneOff,
+          startDate: today,
+        );
+        await Future.delayed(Duration.zero);
+        final id = notifier.state.first.id;
+
+        final specificTime = DateTime(today.year, today.month, today.day, 14, 30);
+        await notifier.toggleTaken(id, today, takenAt: specificTime);
+        await Future.delayed(Duration.zero);
+
+        expect(notifier.state.first.takenLogs.length, 1);
+        expect(notifier.state.first.takenLogs.first, specificTime);
+      });
+    });
+
+    group('setTakenTime', () {
+      late DateTime today;
+
+      setUp(() {
+        final now = DateTime.now();
+        today = DateTime(now.year, now.month, now.day);
+      });
+
+      test('updates the log entry to the new time', () async {
+        final notifier = createNotifier();
+        await notifier.addMedication(
+          name: 'Med',
+          familyMemberId: 'fm-1',
+          type: MedicationType.oneOff,
+          startDate: today,
+        );
+        await Future.delayed(Duration.zero);
+        final id = notifier.state.first.id;
+
+        final originalTime = DateTime(today.year, today.month, today.day, 9, 0);
+        await notifier.toggleTaken(id, today, takenAt: originalTime);
+        await Future.delayed(Duration.zero);
+        expect(notifier.state.first.takenLogs.first, originalTime);
+
+        final newTime = DateTime(today.year, today.month, today.day, 15, 45);
+        await notifier.setTakenTime(id, today, newTime);
+        await Future.delayed(Duration.zero);
+
+        expect(notifier.state.first.takenLogs.length, 1);
+        expect(notifier.state.first.takenLogs.first, newTime);
+      });
+
+      test('is a no-op when no log exists for the given date', () async {
+        final notifier = createNotifier();
+        await notifier.addMedication(
+          name: 'Med',
+          familyMemberId: 'fm-1',
+          type: MedicationType.oneOff,
+          startDate: today,
+        );
+        await Future.delayed(Duration.zero);
+        final id = notifier.state.first.id;
+
+        final newTime = DateTime(today.year, today.month, today.day, 10, 0);
+        await notifier.setTakenTime(id, today, newTime);
+        await Future.delayed(Duration.zero);
+
+        expect(notifier.state.first.takenLogs, isEmpty);
+      });
     });
   });
 }


### PR DESCRIPTION
Implements issue #18:

- Time picker dialog when marking medications as taken (with "Now" shortcut)
- Editable taken-time on medication tile (tap the green "Taken at" label)
- Consistent timestamp display for all medication types when taken
- Time picker in symptom form for both add and edit modes

Closes #18

Generated with [Claude Code](https://claude.ai/code)