### PR TITLE
fix: use temporary type in toggleTaken/setTakenTime tests to avoid on…

### DIFF
--- a/test/features/medications/logic/medication_provider_test.dart
+++ b/test/features/medications/logic/medication_provider_test.dart
@@ -366,8 +366,9 @@ void main() {
         await notifier.addMedication(
           name: 'Toggle Med',
           familyMemberId: 'fm-1',
-          type: MedicationType.oneOff,
+          type: MedicationType.temporary,
           startDate: today,
+          durationInDays: 7,
         );
         await Future.delayed(Duration.zero);
         final id = notifier.state.first.id;
@@ -394,8 +395,9 @@ void main() {
         await notifier.addMedication(
           name: 'Med',
           familyMemberId: 'fm-1',
-          type: MedicationType.oneOff,
+          type: MedicationType.temporary,
           startDate: today,
+          durationInDays: 7,
         );
         await Future.delayed(Duration.zero);
         final id = notifier.state.first.id;
@@ -418,8 +420,9 @@ void main() {
         await notifier.addMedication(
           name: 'Med',
           familyMemberId: 'fm-1',
-          type: MedicationType.oneOff,
+          type: MedicationType.temporary,
           startDate: today,
+          durationInDays: 7,
         );
         await Future.delayed(Duration.zero);
         final id = notifier.state.first.id;


### PR DESCRIPTION
…eOff auto-check

The addMedication method now auto-checks oneOff medications on creation, which caused 3 tests to fail because toggleTaken would toggle OFF the existing log instead of adding a new one. Switch these tests to use temporary medications since they are testing toggle/setTakenTime behavior, not the auto-check feature.