### PR TITLE
feat: add date/time pickers to forms and fix auth persistence

### DIFF
--- a/lib/src/features/auth/logic/auth_provider.dart
+++ b/lib/src/features/auth/logic/auth_provider.dart
@@ -10,17 +10,24 @@ final authStateProvider = StreamProvider<User?>((ref) {
   return FirebaseAuth.instance.authStateChanges();
 });
 
-/// Reads the /users/{uid} doc to get the app-level user (with groupId).
-final appUserProvider = FutureProvider<AppUser?>((ref) async {
+/// Watches the /users/{uid} doc in real-time to get the app-level user (with groupId).
+/// Using a StreamProvider (instead of FutureProvider) ensures:
+///   - automatic updates when auth state or user doc changes
+///   - Firestore offline cache is used on app restart (no network needed)
+///   - no manual ref.invalidate needed after sign-in
+final appUserProvider = StreamProvider<AppUser?>((ref) {
   final authState = ref.watch(authStateProvider);
   final user = authState.valueOrNull;
-  if (user == null) return null;
+  if (user == null) return Stream.value(null);
 
-  final doc =
-      await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
-  if (!doc.exists) return null;
-
-  return AppUser.fromMap(user.uid, doc.data()!);
+  return FirebaseFirestore.instance
+      .collection('users')
+      .doc(user.uid)
+      .snapshots()
+      .map((doc) {
+    if (!doc.exists) return null;
+    return AppUser.fromMap(user.uid, doc.data()!);
+  });
 });
 
 Future<void> signInWithGoogle() async {

--- a/lib/src/features/auth/ui/login_page.dart
+++ b/lib/src/features/auth/ui/login_page.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../logic/auth_provider.dart';
 
-class LoginPage extends ConsumerWidget {
+class LoginPage extends StatelessWidget {
   const LoginPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
         child: Padding(
@@ -21,7 +20,6 @@ class LoginPage extends ConsumerWidget {
                 onPressed: () async {
                   try {
                     await signInWithGoogle();
-                    ref.invalidate(appUserProvider);
                   } catch (e) {
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/src/features/group/ui/group_setup_page.dart
+++ b/lib/src/features/group/ui/group_setup_page.dart
@@ -31,8 +31,6 @@ class _GroupSetupPageState extends ConsumerState<GroupSetupPage> {
     setState(() => _loading = true);
     try {
       await createFamilyGroup(uid);
-      // Re-read user doc to get the new groupId
-      ref.invalidate(appUserProvider);
     } catch (e) {
       setState(() => _error = e.toString());
     } finally {
@@ -54,7 +52,7 @@ class _GroupSetupPageState extends ConsumerState<GroupSetupPage> {
     if (!mounted) return;
 
     if (success) {
-      ref.invalidate(appUserProvider);
+      // appUserProvider (StreamProvider) auto-updates when the user doc changes
     } else {
       setState(() {
         _loading = false;


### PR DESCRIPTION
## Summary
- **Date & time pickers in medication form**: added date picker (defaults to date strip selection) and time picker (like symptoms form) so users can log medications for past/future dates with a specific time
- **Date picker in symptom form**: added date picker above the existing time picker so symptoms can be logged on any date, not just the one selected in the date strip
- **Auth fix**: converted `appUserProvider` from `FutureProvider` to `StreamProvider` watching the Firestore user doc via `.snapshots()` — fixes needing multiple sign-in clicks (race condition) and session loss on app restart (offline cache)

## Test plan
- [ ] Verify all 60 tests pass (`flutter test`)
- [ ] Verify `flutter analyze` reports no issues
- [ ] Sign in with Google — should work on first click
- [ ] Close and reopen app — should stay signed in
- [ ] Add a medication with a custom date and time
- [ ] Add a symptom with a custom date and time
- [ ] Edit an existing medication/symptom and change the date

🤖 Generated with [Claude Code](https://claude.com/claude-code)