### PR TITLE
Fix: deduplicate repeated symptoms on calendar view

### DIFF
--- a/lib/src/features/history/logic/history_provider.dart
+++ b/lib/src/features/history/logic/history_provider.dart
@@ -31,12 +31,20 @@ final historyEventsProvider = Provider<Map<DateTime, List<HistoryEvent>>>((ref) 
   }
 
   // 1. Process Symptoms
+  // Collapse repeats of the same symptom (by family member, title and day)
+  // into a single calendar entry, e.g. measuring a fever 3 times in a day
+  // should still show just one "Fever" marker on that day.
+  final seenSymptoms = <String>{};
   for (final s in symptoms) {
+    final title = s.type == SymptomType.other && s.note != null && s.note!.isNotEmpty
+        ? s.note!
+        : s.type.name[0].toUpperCase() + s.type.name.substring(1);
+    final dedupeKey = '${normalize(s.timestamp)}|${s.familyMemberId}|$title';
+    if (!seenSymptoms.add(dedupeKey)) continue;
+
     addEvent(s.timestamp, HistoryEvent(
       id: s.id,
-      title: s.type == SymptomType.other && s.note != null && s.note!.isNotEmpty
-          ? s.note!
-          : s.type.name[0].toUpperCase() + s.type.name.substring(1),
+      title: title,
       date: s.timestamp,
       color: getFamilyColor(s.familyMemberId),
       type: EventType.symptom,

--- a/test/features/history/logic/history_provider_test.dart
+++ b/test/features/history/logic/history_provider_test.dart
@@ -123,6 +123,126 @@ void main() {
         container.dispose();
       });
 
+      test('collapses repeated symptoms of the same type for the same family member into one event', () {
+        final symptoms = [
+          Symptom(
+            id: 's1',
+            familyMemberId: 'fm-1',
+            timestamp: DateTime(2025, 6, 15, 8, 0),
+            type: SymptomType.fever,
+          ),
+          Symptom(
+            id: 's2',
+            familyMemberId: 'fm-1',
+            timestamp: DateTime(2025, 6, 15, 14, 0),
+            type: SymptomType.fever,
+          ),
+          Symptom(
+            id: 's3',
+            familyMemberId: 'fm-1',
+            timestamp: DateTime(2025, 6, 15, 20, 0),
+            type: SymptomType.fever,
+          ),
+        ];
+
+        final container = makeContainer(symptoms: symptoms);
+        final events = container.read(historyEventsProvider);
+        final dayEvents = events[normalize(DateTime(2025, 6, 15))]!;
+
+        expect(dayEvents.length, 1);
+        expect(dayEvents.first.title, 'Fever');
+        container.dispose();
+      });
+
+      test('keeps separate events for different symptom types on the same day', () {
+        final symptoms = [
+          Symptom(
+            id: 's1',
+            familyMemberId: 'fm-1',
+            timestamp: DateTime(2025, 6, 15, 8, 0),
+            type: SymptomType.fever,
+          ),
+          Symptom(
+            id: 's2',
+            familyMemberId: 'fm-1',
+            timestamp: DateTime(2025, 6, 15, 14, 0),
+            type: SymptomType.fever,
+          ),
+          Symptom(
+            id: 's3',
+            familyMemberId: 'fm-1',
+            timestamp: DateTime(2025, 6, 15, 20, 0),
+            type: SymptomType.cough,
+          ),
+        ];
+
+        final container = makeContainer(symptoms: symptoms);
+        final events = container.read(historyEventsProvider);
+        final dayEvents = events[normalize(DateTime(2025, 6, 15))]!;
+
+        expect(dayEvents.length, 2);
+        expect(dayEvents.map((e) => e.title).toSet(), {'Fever', 'Cough'});
+        container.dispose();
+      });
+
+      test('keeps separate events for the same symptom type logged by different family members', () {
+        final otherMember = FamilyMember(
+          id: 'fm-2',
+          name: 'Bob',
+          colorValue: 0xFF0000FF,
+        );
+        final symptoms = [
+          Symptom(
+            id: 's1',
+            familyMemberId: 'fm-1',
+            timestamp: DateTime(2025, 6, 15, 8, 0),
+            type: SymptomType.fever,
+          ),
+          Symptom(
+            id: 's2',
+            familyMemberId: 'fm-2',
+            timestamp: DateTime(2025, 6, 15, 14, 0),
+            type: SymptomType.fever,
+          ),
+        ];
+
+        final container = makeContainer(
+          family: [familyMember, otherMember],
+          symptoms: symptoms,
+        );
+        final events = container.read(historyEventsProvider);
+        final dayEvents = events[normalize(DateTime(2025, 6, 15))]!;
+
+        expect(dayEvents.length, 2);
+        expect(dayEvents.map((e) => e.color).toSet(),
+            {const Color(0xFFFF0000), const Color(0xFF0000FF)});
+        container.dispose();
+      });
+
+      test('keeps separate events for the same symptom on different days', () {
+        final symptoms = [
+          Symptom(
+            id: 's1',
+            familyMemberId: 'fm-1',
+            timestamp: DateTime(2025, 6, 15, 8, 0),
+            type: SymptomType.fever,
+          ),
+          Symptom(
+            id: 's2',
+            familyMemberId: 'fm-1',
+            timestamp: DateTime(2025, 6, 16, 8, 0),
+            type: SymptomType.fever,
+          ),
+        ];
+
+        final container = makeContainer(symptoms: symptoms);
+        final events = container.read(historyEventsProvider);
+
+        expect(events[normalize(DateTime(2025, 6, 15))]!.length, 1);
+        expect(events[normalize(DateTime(2025, 6, 16))]!.length, 1);
+        container.dispose();
+      });
+
       test('uses family member color', () {
         final symptoms = [
           Symptom(


### PR DESCRIPTION
## Summary
- Fixes #40: logging the same symptom (e.g. fever) multiple times in a day no longer creates multiple markers on the calendar for that day.
- `historyEventsProvider` now deduplicates symptoms by `(normalized date, familyMemberId, displayed title)` before adding a `HistoryEvent`, so repeated logs of the same symptom type by the same person on the same day collapse into a single entry. Different symptom types, different family members, and different days still show separately.

## Test plan
- Added tests to `test/features/history/logic/history_provider_test.dart` covering: repeated same-day same-type symptoms collapsing, different types remaining separate, different family members remaining separate, and different days remaining separate.
- `flutter analyze` / `flutter test` could not be run in this environment (Flutter SDK not available) — please run locally to confirm.

Closes #40

Generated with [Claude Code](https://claude.ai/code)