### PR TITLE
Remove Vitamin D and Iron from medication quick chips

### DIFF
--- a/lib/src/features/medications/ui/add_medication_sheet.dart
+++ b/lib/src/features/medications/ui/add_medication_sheet.dart
@@ -40,8 +40,6 @@ class _AddMedicationSheetState extends ConsumerState<AddMedicationSheet> {
     "Antibiotic",
     "Navisin",
     "Antifungal Cream",
-    "Vitamin D",
-    "Iron",
   ];
 
   // Quick chips that should default to a specific type and duration


### PR DESCRIPTION
## Summary
- Removed "Vitamin D" and "Iron" from the quick-chip suggestions in the Add Medication form

Closes #43

🤖 Generated with [Claude Code](https://claude.ai/code)