### PR TITLE
Add Antibiotic to medication quick-chip defaults

### DIFF
--- a/lib/src/features/medications/ui/add_medication_sheet.dart
+++ b/lib/src/features/medications/ui/add_medication_sheet.dart
@@ -46,6 +46,7 @@ class _AddMedicationSheetState extends ConsumerState<AddMedicationSheet> {
 
   // Quick chips that should default to a specific type and duration
   static const _quickChipDefaults = <String, ({MedicationType type, int? days})>{
+    "Antibiotic": (type: MedicationType.temporary, days: 7),
     "Navisin": (type: MedicationType.temporary, days: 7),
     "Antifungal Cream": (type: MedicationType.temporary, days: 7),
   };


### PR DESCRIPTION
## Summary

Adds "Antibiotic" to the `_quickChipDefaults` map in `AddMedicationSheet` so that selecting the Antibiotic quick chip automatically sets the medication type to "Temporary" and the duration to 7 days, matching the existing behavior for Navisin and Antifungal Cream.

Closes #42.

## Test plan
- [ ] Run `flutter analyze`
- [ ] Run `flutter test`
- [ ] Manually verify: open "Add Medication", tap the "Antibiotic" chip, confirm type is "Temporary" and duration is 7 days

🤖 Generated with [Claude Code](https://claude.ai/code)