### PR TITLE
Swap chip format and color for medications and symptoms in history tab

### DIFF
--- a/lib/src/features/history/ui/history_page.dart
+++ b/lib/src/features/history/ui/history_page.dart
@@ -152,21 +152,21 @@ class _HistoryPageState extends ConsumerState<HistoryPage> {
 
   // The tiny bar inside the calendar cell
   Widget _buildEventBar(HistoryEvent event) {
-    final isSymptom = event.type == EventType.symptom;
+    final isMedication = event.type == EventType.medication;
 
     return Container(
       margin: const EdgeInsets.symmetric(vertical: 0.5, horizontal:1),
       padding: const EdgeInsets.symmetric(horizontal: 2),
       height: 14,
       decoration: BoxDecoration(
-        color: isSymptom ? event.color : Colors.white,
+        color: isMedication ? event.color : Colors.white,
         borderRadius: BorderRadius.circular(2),
-        border: isSymptom ? null : Border.all(color: event.color, width: 1),
+        border: isMedication ? null : Border.all(color: event.color, width: 1),
       ),
       child: Text(
         event.title,
         style: TextStyle(
-          color: isSymptom ? Colors.white : event.color,
+          color: isMedication ? Colors.white : event.color,
           fontSize: 8,
           fontWeight: FontWeight.bold,
         ),


### PR DESCRIPTION
## Summary

Swaps the chip styling between medications and symptoms on the History tab calendar:

- **Before:** Symptoms used a filled chip (solid background, white text); Medications used an outlined chip (white background, colored border/text).
- **After:** Medications now use the filled chip style; Symptoms now use the outlined chip style.

Only the format/color assignment between the two event types is swapped — the underlying per-event color (family member color) is unchanged.

Closes #37.

🤖 Generated with [Claude Code](https://claude.ai/code)