### PR TITLE
Add warning statement to medications

### DIFF
--- a/lib/src/core/models/medication.dart
+++ b/lib/src/core/models/medication.dart
@@ -19,6 +19,10 @@ class Medication {
   // A history of when this specific medication was taken. We store DateTimes here
   final List<DateTime> takenLogs;
 
+  // Optional caution statement shown on the form and the medication list,
+  // e.g. "take every 6 hours, not less"
+  final String? warning;
+
   Medication({
     required this.id,
     required this.name,
@@ -27,6 +31,7 @@ class Medication {
     required this.startDate,
     this.durationInDays,
     this.takenLogs = const [],
+    this.warning,
   });
 
   // A helper method to create a copy of the object with modified fields
@@ -39,6 +44,7 @@ class Medication {
     DateTime? startDate,
     int? durationInDays,
     List<DateTime>? takenLogs,
+    String? warning,
   }) {
     return Medication(
       id: id ?? this.id,
@@ -48,6 +54,7 @@ class Medication {
       startDate: startDate ?? this.startDate,
       durationInDays: durationInDays ?? this.durationInDays,
       takenLogs: takenLogs ?? this.takenLogs,
+      warning: warning ?? this.warning,
     );
   }
 
@@ -59,6 +66,7 @@ class Medication {
       'startDate': Timestamp.fromDate(startDate),
       'durationInDays': durationInDays,
       'takenLogs': takenLogs.map((dt) => Timestamp.fromDate(dt)).toList(),
+      'warning': warning,
     };
   }
 
@@ -75,6 +83,7 @@ class Medication {
               ?.map((t) => (t as Timestamp).toDate())
               .toList() ??
           [],
+      warning: data['warning'] as String?,
     );
   }
 }

--- a/lib/src/features/medications/logic/medication_provider.dart
+++ b/lib/src/features/medications/logic/medication_provider.dart
@@ -50,6 +50,7 @@ class MedicationNotifier extends StateNotifier<List<Medication>> {
     required DateTime startDate,
     int? durationInDays,
     DateTime? takenAt,
+    String? warning,
   }) async {
     final id = const Uuid().v4();
     // Auto-check one-off medications immediately on creation
@@ -64,6 +65,7 @@ class MedicationNotifier extends StateNotifier<List<Medication>> {
       startDate: startDate,
       durationInDays: durationInDays,
       takenLogs: takenLogs,
+      warning: warning,
     );
     await _col.doc(id).set(newMed.toMap());
   }
@@ -75,6 +77,7 @@ class MedicationNotifier extends StateNotifier<List<Medication>> {
     required MedicationType type,
     int? durationInDays,
     required DateTime originalStartDate,
+    String? warning,
   }) async {
     final updatedMed = Medication(
       id: id,
@@ -83,6 +86,7 @@ class MedicationNotifier extends StateNotifier<List<Medication>> {
       type: type,
       startDate: originalStartDate,
       durationInDays: durationInDays,
+      warning: warning,
     );
     await _col.doc(id).set(updatedMed.toMap());
   }

--- a/lib/src/features/medications/ui/add_medication_sheet.dart
+++ b/lib/src/features/medications/ui/add_medication_sheet.dart
@@ -17,6 +17,7 @@ class AddMedicationSheet extends ConsumerStatefulWidget {
 
 class _AddMedicationSheetState extends ConsumerState<AddMedicationSheet> {
   late final TextEditingController _nameController;
+  late final TextEditingController _warningController;
 
   // Tracks which quick-chip name is highlighted (null if user typed manually)
   String? _selectedQuickChipName;
@@ -50,13 +51,22 @@ class _AddMedicationSheetState extends ConsumerState<AddMedicationSheet> {
     "Antifungal Cream": (type: MedicationType.temporary, days: 7),
   };
 
+  // Suggested warning statements for specific quick-chip medications
+  static const _quickChipWarnings = <String, String>{
+    "Paracetamol": "Take every 6 hours, not less",
+    "Ibuprofen": "Take every 8 hours, not less",
+    "Navisin": "Use for a maximum of 7 days, wait 7 days before using it again",
+  };
+
   @override
   void initState() {
     super.initState();
     _nameController = TextEditingController();
+    _warningController = TextEditingController();
     if (widget.medicationToEdit != null) {
       final med = widget.medicationToEdit!;
       _nameController.text = med.name;
+      _warningController.text = med.warning ?? '';
       _selectedType = med.type;
       _selectedMemberId = med.familyMemberId;
       _selectedDate = med.startDate;
@@ -90,10 +100,11 @@ class _AddMedicationSheetState extends ConsumerState<AddMedicationSheet> {
   @override
   void dispose() {
     _nameController.dispose();
+    _warningController.dispose();
     super.dispose();
   }
 
-  // Helper to update name (and optionally type/duration) from quick chips
+  // Helper to update name (and optionally type/duration/warning) from quick chips
   void _fillName(String name) {
     final defaults = _quickChipDefaults[name];
     setState(() {
@@ -110,6 +121,10 @@ class _AddMedicationSheetState extends ConsumerState<AddMedicationSheet> {
     _nameController.selection = TextSelection.fromPosition(
       TextPosition(offset: name.length),
     );
+    final suggestedWarning = _quickChipWarnings[name];
+    if (suggestedWarning != null) {
+      _warningController.text = suggestedWarning;
+    }
   }
 
   @override
@@ -240,6 +255,20 @@ class _AddMedicationSheetState extends ConsumerState<AddMedicationSheet> {
             ),
           ],
 
+          const SizedBox(height: 16),
+
+          // Warning Input
+          TextField(
+            controller: _warningController,
+            maxLines: 2,
+            decoration: const InputDecoration(
+              labelText: "Warning (optional)",
+              hintText: "e.g., take every 6 hours, not less",
+              prefixIcon: Icon(Icons.warning_amber_rounded, color: Colors.orange),
+              border: OutlineInputBorder(),
+            ),
+          ),
+
           const Divider(height: 30),
 
           // DATE PICKER ROW
@@ -319,6 +348,8 @@ class _AddMedicationSheetState extends ConsumerState<AddMedicationSheet> {
                   _selectedDate.year, _selectedDate.month, _selectedDate.day,
                   _selectedTime.hour, _selectedTime.minute,
                 );
+                final trimmedWarning = _warningController.text.trim();
+                final warning = trimmedWarning.isEmpty ? null : trimmedWarning;
                 // EDIT MODE
                 if (widget.medicationToEdit != null) {
                   ref.read(medicationProvider.notifier).editMedication(
@@ -328,6 +359,7 @@ class _AddMedicationSheetState extends ConsumerState<AddMedicationSheet> {
                     type: _selectedType,
                     durationInDays: _selectedType == MedicationType.temporary ? _durationDays.toInt() : null,
                     originalStartDate: _selectedDate,
+                    warning: warning,
                   );
                 }
                 // ADD MODE
@@ -339,6 +371,7 @@ class _AddMedicationSheetState extends ConsumerState<AddMedicationSheet> {
                     startDate: _selectedDate,
                     durationInDays: _selectedType == MedicationType.temporary ? _durationDays.toInt() : null,
                     takenAt: takenAt,
+                    warning: warning,
                   );
                 }
 

--- a/lib/src/features/medications/ui/daily_medication_list.dart
+++ b/lib/src/features/medications/ui/daily_medication_list.dart
@@ -255,6 +255,23 @@ class DailyMedicationList extends ConsumerWidget {
                   )
                 else
                   Text(subtitleText),
+                if (med.warning != null && med.warning!.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Icon(Icons.warning_amber_rounded, size: 14, color: Colors.orange),
+                        const SizedBox(width: 4),
+                        Expanded(
+                          child: Text(
+                            med.warning!,
+                            style: const TextStyle(fontSize: 12, color: Colors.orange),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
               ],
             ),
             trailing: Row(

--- a/test/features/medications/logic/medication_provider_test.dart
+++ b/test/features/medications/logic/medication_provider_test.dart
@@ -138,6 +138,35 @@ void main() {
         expect(snap.docs.length, 1);
         expect((snap.docs.first.data() as Map)['name'], 'Persisted Med');
       });
+
+      test('stores and round-trips a warning statement', () async {
+        final notifier = createNotifier();
+        await notifier.addMedication(
+          name: 'Paracetamol',
+          familyMemberId: 'fm-1',
+          type: MedicationType.oneOff,
+          startDate: DateTime(2025, 6, 15),
+          warning: 'Take every 6 hours, not less',
+        );
+        await Future.delayed(Duration.zero);
+
+        expect(notifier.state.first.warning, 'Take every 6 hours, not less');
+        final doc = await medsCol().doc(notifier.state.first.id).get();
+        expect((doc.data() as Map)['warning'], 'Take every 6 hours, not less');
+      });
+
+      test('defaults warning to null when not provided', () async {
+        final notifier = createNotifier();
+        await notifier.addMedication(
+          name: 'Vitamin D',
+          familyMemberId: 'fm-1',
+          type: MedicationType.permanent,
+          startDate: DateTime(2025, 1, 1),
+        );
+        await Future.delayed(Duration.zero);
+
+        expect(notifier.state.first.warning, isNull);
+      });
     });
 
     group('editMedication', () {
@@ -164,6 +193,33 @@ void main() {
         expect(notifier.state.first.name, 'New Name');
         final doc = await medsCol().doc(id).get();
         expect((doc.data() as Map)['name'], 'New Name');
+      });
+
+      test('updates the warning statement and persists', () async {
+        final notifier = createNotifier();
+        await notifier.addMedication(
+          name: 'Ibuprofen',
+          familyMemberId: 'fm-1',
+          type: MedicationType.oneOff,
+          startDate: DateTime(2025, 6, 15),
+          warning: 'Take every 8 hours, not less',
+        );
+        await Future.delayed(Duration.zero);
+        final id = notifier.state.first.id;
+
+        await notifier.editMedication(
+          id: id,
+          name: 'Ibuprofen',
+          familyMemberId: 'fm-1',
+          type: MedicationType.oneOff,
+          originalStartDate: DateTime(2025, 6, 15),
+          warning: 'Take every 6 hours, not less',
+        );
+        await Future.delayed(Duration.zero);
+
+        expect(notifier.state.first.warning, 'Take every 6 hours, not less');
+        final doc = await medsCol().doc(id).get();
+        expect((doc.data() as Map)['warning'], 'Take every 6 hours, not less');
       });
     });
 


### PR DESCRIPTION
## Summary

Adds an optional warning/caution statement to medications, shown both on the add/edit form and in the medication list.

- Added a nullable `warning` field to the `Medication` model with Firestore serialization
- Threaded `warning` through `MedicationNotifier.addMedication/editMedication`
- Added a "Warning (optional)" text field to the add/edit medication form, pre-filled with suggested text for Paracetamol/Ibuprofen/Navisin quick-chips
- Display the warning on each medication list item with a caution icon
- Added tests covering persistence, round-tripping, and editing of the warning

Closes #34

## Test plan

- [ ] Run `flutter analyze` and `flutter test`
- [ ] Manually verify the warning field appears on the add/edit medication form and pre-fills for Paracetamol/Ibuprofen/Navisin
- [ ] Manually verify the warning renders on medication list items

Generated with [Claude Code](https://claude.ai/code)